### PR TITLE
12 Inframodel <Feature> extensions

### DIFF
--- a/markdown/im_extensions.md
+++ b/markdown/im_extensions.md
@@ -165,12 +165,14 @@ If the project consists of sub-projects that have different rates of progress, t
 
 Calculated area of a surface (**\<Surface>**) or the volume below (between two surfaces) can be transferred using "IM_quantity" extension. These quanties may also be assingned to a part of a surface (**\<Surface>**.**\<SourceData>**.**\<Boundaries>**.**\<Boundary>**) or an area defined as a **\<Parcel>**.
 
-{{xtabulate5 IM_quantity}}
+{{xtabulate IM_quantity--ltFeature--gt}}
 
 
 ## Soil properties {#sec:soilpropertiesext}
 
 Soil properties of terrain model or ground layer model are captured in "IM_soil" feature extension.
+
+{{xtabulate IM_soil--ltFeature--gt}}
 
 **Details:**  
 
@@ -178,38 +180,29 @@ Soil properties of terrain model or ground layer model are captured in "IM_soil"
 
 {{refsec groundlayermodel}}
 
+
 ## String line model {#sec:stringlinemodelext}
 
 The string line model is composed of *line string alignments* **\<IrregularLine>**. Their order with an **\<Alignment>** is irrelevant. The string line model used in Inframodel is based on the Leica RoadRunner software.
 
-The string line model is defined under an **\<Alignment>** in the **"IM\_stringlineLayers"** extension. The constituent line strings and their locations are set by layer in the **"IM_stringlineLayer"** child element.  The order of description of the line strings does not matter, the alignments are identified by their unique name **\<Aligenment>.name**, which are listed in the element, separated by commas. A layer is assigned a **name** and optionally a **centerline**. When describing a layered structure the layers of the string line model are assigned surface codes **SurfaceCoding**. The same line string may belong to several different layers. Layer are listed starting from the top downwards.
+The string line model is defined under an **\<Alignment>** in the **"IM\_stringlineLayers"** extension. The constituent line strings and their locations are set by layer in the **"IM_stringlineLayer"** child element.  The order of description of the line strings does not matter, the alignments are identified by their unique name **\<Alignment>.** name, which are listed in the element, separated by commas. A layer is assigned a **name** and optionally a **centerline**. When describing a layered structure the layers of the string line model are assigned surface codes **SurfaceCoding**. The same line string may belong to several different layers. Layer are listed starting from the top downwards.
+
+{{xtabulate IM_stringlineLayers--ltFeature--gt}}
+
+{{xtabulate IM_stringlineLayer--ltFeature--gt}}
 
 **Details:**
 
 {{refsec stringlinemodel}}
 
+
 ## Cross-section parameters {#sec:crosssectionparametersext}
 
 *Cross-section parameters* contain parametric information considered crucial for each route type. They are set for the *stationing reference alignment* in the **\<CrossSects>**.**\<CrossSect>** "IM_crossSect" extension under the **\<Alignment>** element. The chosen cross-section parameters are set in fields (**\<Property>**). It is advisable to describe all parameters for each cross-section. If the some parameters change, the cross-section where the parameter begins to change and the end of the transition are described.
 
-The described parameters vary by route type:
+{{xtabulate CrossSect--ltFeature--gt}}
 
-**parameters in road and street planning**
-- **pavementClass**
-- **pavementThickness**
-- **subgradeLoadCapacityClass**
-- (perpendicular) **slope**
-
-**railway planning parameters**
-- number of **tracks**
-- track distance **trackDist**
-- **thickness** of permanent way
-- track bed width **bedWidth**
-
-**waterway planning parameters**
-- minumum **depth**
-- waterway **width**
-- dimensioning water level height **waterLevel**
+{{xtabulate IM_CrossSect--ltFeature--gt}}
 
 **Details:**
 
@@ -219,13 +212,16 @@ The described parameters vary by route type:
 
 {{refsec crosssectionparameters}}
 
+
 ## Strcutural layer properties {#sec:structureallayerpropertiesext}
 
 Material properties of layers in road, street or railway structual model are captured in "IM_structLayer" feature extension.
 
+{{xtabulate IM_structLayer--ltFeature--gt}}
+
 **Details:**  
 
-{{refsec roadandstreetsstructurallayers}}
+{{refsec roadsandstreetsstructurallayers}}
 
 {{refsec railwaystructurallayers}}
 
@@ -233,46 +229,42 @@ Material properties of layers in road, street or railway structual model are cap
 
 Road signs belonging to a particular route design are described in **\<Roadways>**.**\<Roadway>**.**\<Roadside>**.**\<RoadSign>**, with detailed properties captured in "IM_roadSign" feature extension:
 
-{{xtabulate5 IM_roadSign}}
+{{xtabulate IM_roadSign--ltFeature--gt}}
 
 ## Railway design - KM post coordinates {#sec:kmpostcoordinatesext}
 
 To assign northing and easting coordinates to railway **\<Alignment>**.**\<StationEquation>**, the parameters are:
 
-- northing coordinate **northing**
-- easting coordinate **easting**
+{{xtabulate IM_kmPostCoords--ltFeature--gt}}
 
 **Details:**
 
 {{refsec kmposting}}
 
+
+
 ## Railway design - switches {#sec:switchesext}
 
 Switch details at railway track **\<Alignment>**.**\<CoordGeom>**.**\<Line>**, the parameters are:
 
-- switch type **switchType**
-- switch hand **switchHand**
-- switch joint **switchJoint**
+{{xtabulate IM_switch--ltFeature--gt}}
 
 **Details:**
 
-{{refsec switch}}
+{{refsec switchinformation}}
+
 
 ## Utility networks - network type {#sec:networktypeext}
 
 When the attribute pipeNetType in \>PipeNetwork> element is set to 'other', the type of utility network may be speficied in "IM_pipeNetworkType" extension:
 
-- districtheating
-- districtcooling
-- gas
-- waste transport piping
-- cable
+{{xtabulate IM_pipeNetworkType--ltFeature--gt}}
 
 ## Utility networks - structure details {#sec:structuredetailsext}
 
 It is possible to describe additional details of network structures described in inframodel file transfers. The parameters in "IM_struct" are:
 
-{{xtabulate5 IM_struct}}
+{{xtabulate IM_struct--ltFeature--gt}}
 
 **Details:**
 
@@ -282,7 +274,7 @@ It is possible to describe additional details of network structures described in
 
 {{refsec pipeinletsandoutlets}}
 
-{{refsec pipeconnections}}
+{{refsec pipeconnection}}
 
 {{refsec equipment}}
 
@@ -290,7 +282,7 @@ It is possible to describe additional details of network structures described in
 
 It is possible to describe additional details of pipes of a network described in inframodel file transfers. The parameters in "IM_pipe" are:
 
-{{xtabulate5 IM_pipe}}
+{{xtabulate5 IM_pipe--ltFeature--gt}}
 
 **Details:**
 
@@ -298,9 +290,9 @@ It is possible to describe additional details of pipes of a network described in
 
 {{refsec eggpipes}}
 
-{{refsec ellipticpipes}}
+{{refsec ellipticpipe}}
 
-{{refsec rectangularpipes}}
+{{refsec rectangularpipe}}
 
 {{refsec channels}}
 
@@ -308,28 +300,33 @@ It is possible to describe additional details of pipes of a network described in
 
 It is possible to describe additional details of cables of a network described in inframodel file transfers. The parameters in "IM_cable" are:
 
-{{xtabulate5 IM_cable}}
+{{xtabulate IM_cable--ltFeature--gt}}
 
 **Details:**
 
-{{refsec cables}}
+{{refsec cable}}
 
 ## Plan features {#sec:planfeaturesext}
 
 Planimetric features belonging to a particular route design are described in **\<Roadways>**.**\<Roadway>**.**\<PlanFeature>**, or in other cases in **\<PlanFeatures>**.**\<PlanFeature>**. In addition of capability of being classified using "IM_coding" extension (and/or "IM_proprietaryCoding") and having custom properties using "IM_userDefinedProperties", detailed propeties may be assigned by the type of plan feature:
 
-- cable properties in **"IM_cable"**
-- footing properties in **"IM_footing"**
-- railing properties in **"IM_railing"**
-- fence properties in **"IM_fence"**
-- surface structure properties in **"IM_surfaceStruct"**
-- generic (none of the above) properties in **"IM_planFeature"**
+{{xtabulate IM_cable--ltFeature--gt}}
+
+{{xtabulate IM_footing--ltFeature--gt}}
+
+{{xtabulate IM_railing--ltFeature--gt}}
+
+{{xtabulate IM_fence--ltFeature--gt}}
+
+{{xtabulate IM_surfaceStructure--ltFeature--gt}}
+
+{{xtabulate IM_planFeature--ltFeature--gt}}
 
 **Details:**
 
 {{refsec roadplanfeatures}}
 
-{{refsec railplanfeatures}}
+{{refsec railwayplanfeatures}}
 
 {{refsec waterwayplanfeatures}}
 
@@ -339,7 +336,7 @@ Planimetric features belonging to a particular route design are described in **\
 
 Inframodel enables transfering both planned control points with tolerances (**\<Cgpoints>** as top-level collection), and the measured values (**\<Survey>**.**\<Cgpoints>**), both having detailed properties assign to the collection as "IM_cgpoints":
 
-{{xtabulate IM_cgpoints}}
+{{xtabulate IM_cgpoints--ltFeature--gt}}
 
 **Details:**
 
@@ -350,13 +347,13 @@ Inframodel enables transfering both planned control points with tolerances (**\<
 
 An area or a space allocated for some specific use, or a perimeter around an object to be avoided can be defined using "IM_spatialZone" extension, applicable to  **\<PlanFeature>**, **\<Parcel>**, **\<Pipe>** or **\<Struct>**.
 
-{{xtabulate IM_spatialZone}}
+{{xtabulate IM_spatialZone--ltFeature--gt}}
 
 **Details:**
 
 {{refsec planimetricfeatures}}
 
-{{refsec parcels}}
+{{refsec surfacetructures}}
 
 {{refsec structures}}
 

--- a/markdown/pipenetworks.md
+++ b/markdown/pipenetworks.md
@@ -60,7 +60,7 @@ In Inframodel, the same metric units (as specified in the header-section) shall 
 
 {{xtabulate Pipenetworkunits}}
 
-## Structures
+## Structures {#sec:structures}
 
 The topological network consists of different kinds of structures whose exact location is defined in the file. The different structures in the **\<PipeNetwork>** compose the *structure group* **\<Structs>**, that has no attributes.
 

--- a/markdown/railways.md
+++ b/markdown/railways.md
@@ -18,7 +18,7 @@ The detailed description of the construction process of line string model can be
 ![String line representation of railway]({{figure Rail_stringlinemodel.png}} "String line representation of railway"){{figst stringlinerepresentationofrailway}}
 
 
-## KM-posting
+## KM-posting {#sec:kmposting}
 
 The KM-posting method in inframodel uses **\<StaEquation>** in a way that somewhat differs from its typical use in LandXML. The individual km-post station distances from the previous post station are defined by their back stations **staBack** (for the first KM-post on a given alignment, the **staBack** can be set to "NaN", when it is not known or relevant). This use of **\<StaEquation>** does not imply a re-start in the alignment stationing, hence in inframodel the **staAhead** attribute is always set to the same value as **staInternal** attribute. Individual locations according to the KM-posting system on all tracks are presented in relation to the KM-posting reference alignment. The name of the KM-post station is defined by the **desc** attribute.
 
@@ -28,7 +28,7 @@ Although the Finnish KM-posting system is nominally kilometre based, it cannot b
 
 ![KM-posting]({{figure KM_paalutus.png}} "KM-posting"){{figst kmposting}}
 
-{{xtabulate Feature}}
+{{xtabulate IM_kmPostCoords--ltFeature--gt}}
 
 ## Cross-sections and track information {#sec:crosssectionsandtrackinformation}
 
@@ -74,7 +74,7 @@ The following transitions are described by the track information sub-element:
 
 {{xtabulate SpeedStation}}
 
-### Switch information
+### Switch information {#sec:switchinformation}
 
 The information on switches of tracks is given under track centerlines in the **\<Alignment>**.**\<CoordGeom>**.**\<Line>** using "IM_switch" **\<Feature>**
 

--- a/markdown/railways.md
+++ b/markdown/railways.md
@@ -30,7 +30,7 @@ Although the Finnish KM-posting system is nominally kilometre based, it cannot b
 
 {{xtabulate Feature}}
 
-## Cross-sections and track information
+## Cross-sections and track information {#sec:crosssectionsandtrackinformation}
 
 Cross-section plan contains information that fleshes out the geometry and string line model descriptions of the railway. The information contained by the cross-section element is valid from the given station forward, either to the next transition cross-section element or the end of the line. The cross-section parameters are described under the KM-posting reference track in the **\<Alignment>**.**\<CrossSects>**.**\<CrossSect>** element and its extension "IM_crossSect" (**\<Feature>**).
 

--- a/markdown/roadsandstreets.md
+++ b/markdown/roadsandstreets.md
@@ -52,7 +52,7 @@ The cross-section parameters describe the situation at a given station, includin
 ![Road cross section]({{figure Road_crossSect_slope.png}} "Road cross section"){{figst roadcrosssection}}
 
 
-### Cross-section parameters
+### Cross-section parameters {#sec:crosssectparameters}
 
 *The cross-section parameters* are set under **\<Alignment>**.**\<CrossSects>**.**\<CrossSect>** in the extension "IM_crossSect". The *cross-section parameters* are optional in street designs.
 

--- a/markdown/routeplanning.md
+++ b/markdown/routeplanning.md
@@ -144,7 +144,7 @@ A *line string* has optional attributes and sub-elements to define its **\<Start
 
 {{xtabulate IrregularLine}}
 
-## String line model
+## String line model {#sec:stringlinemodel}
 
 An *alignment group* **\<Alignments>** is a collection of geometric alignments and line strings. The string line model of a route is composed of their descriptions in the file, ordered into layers. The order of *alignment* descriptions within the *alignment group* does not matter. The string line model used in Inframodel is based on the Leica RoadRunner software.
 

--- a/markdown/waterways.md
+++ b/markdown/waterways.md
@@ -13,7 +13,7 @@ The alignment group must contain at least one continuous geometric alignment as 
 
 The order the individual **\<Alignment>** elements are described in under the **\<Alignments>** element does not matter. The *type coding* of individual *alignments* defines the purpose of the *alignment*. A **terrainCoding**-compliant *terrain code* is set in the extension "IM\_coding". Selected alignments are included in the *line string model*, defined in the extension "IM\_stringLineLayers". The *line string model* consists of alignments structured into surfaces using a **surfaceCoding**. The *surface model* and *structural model* of the design are defined as triangle meshes. The plan information is optionally set in the "IM_plan" extension.
 
-## Cross section parameters
+## Cross section parameters {#sec:crosssectionparameters}
 
 The cross-section parameters of an *alignment group* describe the values of cross-sectional parameters from a the given station onwards. The cross-section parameters are set in the extension "IM_crossSect". The extension is implemented in a fashion similar to road and street design. The parameters are *minimum* **depth** of the route, the *minimum* **width** and the dimensioning **waterLevel**. The dimensioning water level is situation-specific and might be e.g. average daily low or average daily mean water level. The described Cross-section parameters are valid from the set station onwards.
 


### PR DESCRIPTION
Extensions fiksauksia ja sec viittauksia. Alla lista muutoksista.

!!!HUOM!! kohtiin 12.2 ja 12.3 ei tehty muutoksia!!! -> katsotaan yhdessä mikä taulukko mihinkin kuuluu

12 Inframodel <Feature> extensions
		
			”…in chapters 1-11…”  ”In this document” ok
			Taulukon 12.26 alla: ”TODO-MISSING…”ok 
			Luku 12.5
				Lisätään IM_plan -taulukko ok
				??-viittauksia ok
			Luku 12.6, Quantity-taulukko puuttuu ok
			Luku 12.7, taulukko puuttuu ok
			Luku 12.8, taulukko puuttuu, typoja (Aligenment), viittaukset vinossa ok
			Luku 12.9, taulukot puuttuvat ja viittaukset rikki ok
			Luku 12.10, taulukko puuttuu, viittaukset rikki ok
			Luku 12.11, taulukko puuttuu ok
			Luku 12.12, viittaus rikki, taulukko puuttuu ok
			Luku 12.13, viittaus rikki, taulukko puuttuu ok
			Luku 12.14, taulukko puuttuu, bullet point lista pois. ok
			Luku 12.15, taulukko puuttuu, viittaus rikki ok
			Luku 12.16, taulukko rikki, viittaus rikki ok
			Luku 12.17, taulukko rikki, viittaus rikki ok
			Luku 12.18, viittaus rikki, taulukko puuttuu kaikista listan kohdista (cable, footing, railing, fence, jne.) ok
			Luku 12.19, taulukko rikki, viittaus rikki ok
			Luku 12.20, taulukko rikki, viittaus rikki ok