### PR TITLE
headers ja base data korjaukset

### DIFF
--- a/markdown/basedata.md
+++ b/markdown/basedata.md
@@ -86,11 +86,11 @@ Source *breakline group* is described by the element \<BreakLines>, where each \
 
 Additionally, it is also possible to define boundaries of the source data in the boundary group \<Boundaries>, where each \<Boundary> is presented in its own element. Each boundary may have properties of the area as "IM_surfaceStructure", "IM_structLayer" or "IM_soil", as well as calculated area or volume quantities as "IM_quantity". 
 
-{{xtabulate Boundaries--ltFeature--gt}}
+{{xtabulate Boundaries}}
 
-{{xtabulate Boundary--ltFeature--gt}}
+{{xtabulate Boundary}}
  
-{{xtabulate IM_surfaceStructure--ltFeature--gt}}
+{{xtabulate IM_surfaceStructure}}
  
 {{xtabulate IM_structLayer--ltFeature--gt}}
  

--- a/markdown/basedata.md
+++ b/markdown/basedata.md
@@ -90,7 +90,7 @@ Additionally, it is also possible to define boundaries of the source data in the
 
 {{xtabulate Boundary}}
  
-{{xtabulate IM_surfaceStructure}}
+{{xtabulate IM_surfaceStructure--ltFeature--gt}}
  
 {{xtabulate IM_structLayer--ltFeature--gt}}
  

--- a/markdown/basedata.md
+++ b/markdown/basedata.md
@@ -86,9 +86,9 @@ Source *breakline group* is described by the element \<BreakLines>, where each \
 
 Additionally, it is also possible to define boundaries of the source data in the boundary group \<Boundaries>, where each \<Boundary> is presented in its own element. Each boundary may have properties of the area as "IM_surfaceStructure", "IM_structLayer" or "IM_soil", as well as calculated area or volume quantities as "IM_quantity". 
 
-{{xtabulate Boundaries}}
+{{xtabulate Boundaries--ltFeature--gt}}
 
-{{xtabulate Boundary}}
+{{xtabulate Boundary--ltFeature--gt}}
  
 {{xtabulate IM_surfaceStructure--ltFeature--gt}}
  

--- a/markdown/basedata.md
+++ b/markdown/basedata.md
@@ -41,7 +41,7 @@ The type coding systems used in Inframodel file transfers are set in the header 
 
 Type coding is set by "IM_Coding" \<Feature> extension under a parent element.
 
-{{xtabulate5 IM_Coding--ltFeature--gt}}
+{{xtabulate IM_coding--ltFeature--gt}}
 
 Individual type codes are set primarily in parent elements, from which the child elements will inherit the values. 
 Terrain points and breaklines are type coded using the **terrainCoding** and a coding description **terrainCodingDesc**.
@@ -49,14 +49,14 @@ It is optional to set a **surfaceCoding** and a surface coding description **sur
 Surfaces are given a **surfaceCoding** and a surface coding description **surfaceCodingDesc**, and optionally **terrainCoding** and a coding description **terrainCodingDesc**.
 These both may be given an **infraCoding** and its description **infraCodingDesc**. 
  
-Alternative type codings can be given using "IM_proprietaryCoding" with **proprietaryInfraCoding** and their descriptions **proprietaryInfraCodingDesc**, and with **proprietaryInfraCodingSource* where they both have prefix per proprietary coding systems named under \<Project> element.
+Alternative type codings can be given using "IM_proprietaryCoding" with **proprietaryInfraCoding** and their descriptions **proprietaryInfraCodingDesc**, and with **proprietaryInfraCodingSource** where they both have prefix per proprietary coding systems named under \<Project> element.
 Type coding set by the parent element is also inherited by the child elements, ie. \<Surfaces> element may also set the type coding of its child elements.
 
 ### Quantity information {#sec:quantityinformation}
 
 Calculated area or volume quantities may be assinged to entire \<Surface>, or part of it in source data \<Boundary>, using "IM_quantity" extension:
  
-{{xtabulate5 IM_quantity}}
+{{xtabulate IM_quantity--ltFeature--gt}} 
  
 ## Source data {#sec:sourcedata}
 
@@ -90,13 +90,13 @@ Additionally, it is also possible to define boundaries of the source data in the
 
 {{xtabulate Boundary}}
  
-{{xtabulate IM_surfaceStructure}}
+{{xtabulate IM_surfaceStructure--ltFeature--gt}}
  
-{{xtabulate IM_structLayer}}
+{{xtabulate IM_structLayer--ltFeature--gt}}
  
-{{xtabulate IM_soil}}
+{{xtabulate IM_soil--ltFeature--gt}}
  
-{{xtabulate IM_quantity}}
+{{xtabulate IM_quantity--ltFeature--gt}}
 
 ## Triangular mesh surface {#sec:triangulatedmeshsurface}
 
@@ -144,15 +144,14 @@ It consists of the vertices of the component faces <Pnts> and the faces <Faces> 
 In inframodel file transfers it is also possible to assign source data points and breaklines to the surface.
 An "IM_coding" \<Feature> extension enables surface classifications, and "IM_soil" \<Feature> extension allows to add the technical properties. 
 Terrain model may be part of a optional plan described in "IM_plan" \<Feature>. 
-When exchanging a terrain model, the attribute \<Surfaces>.desc shall be set to "terrain model". TODO:why?
 
+![Terrain model]({{figure Surfaces_terrain.png}} "Terrain model"){{figst terrainmodel}}
+ 
 ### Soil properties {#sec:soilproperties}
 
 When no information of individual ground layers is available, surface model may define the soil propertites below the topmost surface by using "IM_soil" \<Feature> extension.
 
-{{xtabulate4 IM_Soil--ltFeature--gt}}
-
-![Soil properties]({{figure Surfaces_terrain.png}} "Soil properties"){{figst soilproperties}}
+{{xtabulate IM_soil--ltFeature--gt}}
 
 ## Ground layer model {#sec:groundlayermodel}
 
@@ -161,11 +160,9 @@ It is recommended that surfaces are described top-down. Individual layer surface
 A surface may be part of a plan described in "IM_plan" \<Feature>. 
 A "IM_coding" \<Feature> extension provides surface classifications. 
 The technical properties of each soil layer between two surfaces may be given in "IM_soil" <Feature> extension described above. 
-When exchanging a ground layer model as collection of Surfaces, the attribute <Surfaces>.desc shall be set to "ground layer model". TODO:why
 
 ![Ground layer model]({{figure Surfaces_Maaperamalli.png}} "Ground layer model"){{figst groundlayermodel}}	
- 
-![Triangulated ground model]({{figure Surfaces_kolmiomalli.png}} "Triangulated ground model"){{figst triangulatedgroundmodel}}	
+
 
 
 

--- a/markdown/headers.md
+++ b/markdown/headers.md
@@ -171,7 +171,7 @@ The name attribute shall be unique, and always 'inframodel' for the dictionary o
 
 The \<version> should match the version number of the Inframodel schema. 
   
-Optional \<DocFileRef> element can be used to provide the URI link to named external documentation where applicable feature code and property type values are described ( {{resec inframodelfeatureextensions}} in the case of Inframodel feature dictionary).
+Optional \<DocFileRef> element can be used to provide the URI link to named external documentation where applicable feature code and property type values are described ( {{refsec inframodelfeatureextensions}} in the case of Inframodel feature dictionary).
 
 {{xtabulate FeatureDictionary}}
 

--- a/markdown/headers.md
+++ b/markdown/headers.md
@@ -68,7 +68,7 @@ It is also possible to set a rotationAngle for the coordinate system.
 ### Local coordinate transformation by point pairs {#sec:localcoordinatetransfromationbypointpairs}
 
 Local coordinate system may be defined as set of control points sourceCRS-targetCRS point pairs under "IM_coordTransformation" \<Feature> extension. 
-See {{refto IM_coordTransformation-feature}} for detailed information about "IM_coordTransformation" \<Feature> extension.
+See {{refsec localcoordinatetransfromationbypointpairsext}} for detailed information about "IM_coordTransformation" \<Feature> extension.
 
 ### Local coordinate transformation by transformation parameters {#sec:localcoordinatetransfromationbytransformationparameters}
 
@@ -129,11 +129,7 @@ where:
 
 {{xtabulate stateType}}
 
-Detailed information about "IM_codings", "IM_proprietaryCodings" and "IM_userDefinedProperties" \<Feature> extensions can be found from {{refto IMFeatureEXT}}
-
-- "IM_codings" \<Feature> extension,{{refto IM_codings-feature}}
-- "IM_proprietaryCodings" \<Feature> extension,{{refto IM_proprietaryCodings-feature}}
-- "IM_userDefinedProperties" \<Feature> extension,{{refto IM_userDefinedProperties-feature}}  
+Detailed information about "IM_codings", "IM_proprietaryCodings" and "IM_userDefinedProperties" \<Feature> extensions can be found from {{refsec inframodelfeatureextensions}}
 
 
 ## Type coding systems {#sec:typecodingsystems}
@@ -148,20 +144,20 @@ The main coding systems are set in the "IM_codings" extension *(exactly one in e
 
 The existing terrain description contains source data points and breaklines. The surface description consists of the individual surfaces of the base data (terrain and ground layers) or the planned route or areal structures as TIN surface model or string line model. In addtion to surfaces, planned objects may be described as alignment geometry, line strings or points. It is possible to set the same type coding system for more than one of these.
 
-In addition to the main coding systems, it is also possible to define additional or alternative type coding systems *(none, one or more e.g. InfraRAK2.3, Vesilaitos X, Kaupunki Y etc.)*, using "IM_proprietaryCodings" extension (one instance per coding system) under \<Project>. When a code from a proprietary system is used for an element, each "IM_proprietaryCoding" \<Feature> instance placed under the element being coded shall identify the coding system by its property proprietaryInfraCodingSource, having the same value as the system name set in "IM_proprietaryCodings" property proprietaryInfraCoding.
+In addition to the main coding systems, it is also possible to define additional or alternative type coding systems *(none, one or more e.g. Company X etc.)*, using "IM_proprietaryCodings" extension (one instance per coding system) under \<Project>. When a code from a proprietary system is used for an element, each "IM_proprietaryCoding" \<Feature> instance placed under the element being coded shall identify the coding system by its property proprietaryInfraCodingSource, having the same value as the system name set in "IM_proprietaryCodings" property proprietaryInfraCoding.
 
 
 ## Application {#sec:application}
 
 The \<Application> element describes what software was used to create the file. If the file has been created using several different applications, all are described by their own \<Application> element.
 
-{{xtabulate4 Application}}
+{{xtabulate Application}}
 
 ## Authors {#sec:authors}
 
 Information of the author of the file is recorded in the sub-element \<Application>.\<Author>. It is possible to define several authors as separate \<Author>-elements.
 
-{{xtabulate4 Author}}
+{{xtabulate Author}}
 
 ## Feature dictionary {#sec:featuredictionary}
 
@@ -175,9 +171,9 @@ The name attribute shall be unique, and always 'inframodel' for the dictionary o
 
 The \<version> should match the version number of the Inframodel schema. 
   
-Optional \<DocFileRef> element can be used to provide the URI link to named external documentation where applicable feature code and property type values are described ({{refto IMExtensions}} in the case of Inframodel feature dictionary).
+Optional \<DocFileRef> element can be used to provide the URI link to named external documentation where applicable feature code and property type values are described ({{resec inframodelfeatureextensions}} in the case of Inframodel feature dictionary).
 
-{{xtabulate4 FeatureDictionary}}
+{{xtabulate FeatureDictionary}}
 
 Proprietary extensions can be included in addition to Inframodel extensions, as "IM_userDefinedProperties" (generic extension specified in Inframodel feature dictionary), with mandatory propertyLabel (name of the property from proprietary source) and propertyValue (value set for the property in this instance), and optional propertyDescription (description or definition of the property from proprietary source) and propertySource (identification of or reference to the property definition source).
 
@@ -187,4 +183,4 @@ Metadata is described with the **\<im:Metadata>** element (specified im-extensio
 
 Metadata is optional and enables the following features shown below.
   
-{{xtabulate IM-Metadata}}
+{{xtabulate IM_Metadata--ltFeature--gt}}

--- a/markdown/headers.md
+++ b/markdown/headers.md
@@ -171,7 +171,7 @@ The name attribute shall be unique, and always 'inframodel' for the dictionary o
 
 The \<version> should match the version number of the Inframodel schema. 
   
-Optional \<DocFileRef> element can be used to provide the URI link to named external documentation where applicable feature code and property type values are described ({{resec inframodelfeatureextensions}} in the case of Inframodel feature dictionary).
+Optional \<DocFileRef> element can be used to provide the URI link to named external documentation where applicable feature code and property type values are described ( {{resec inframodelfeatureextensions}} in the case of Inframodel feature dictionary).
 
 {{xtabulate FeatureDictionary}}
 
@@ -183,4 +183,4 @@ Metadata is described with the **\<im:Metadata>** element (specified im-extensio
 
 Metadata is optional and enables the following features shown below.
   
-{{xtabulate IM_Metadata--ltFeature--gt}}
+{{xtabulate IM_metadata}}


### PR DESCRIPTION
1 File headers
		
Luku 1.4.1 Local coordinate transformation… Linkitys väärin/puuttuu ”See subsection ??...” ok
Taulukko 1.15, alapuolella nippu puuttuvia/virheellisiä linkityksiä (??) ok
Luku 1.6, korvataan suomenkieliset termit (Vesilaitos X, Kaupunki Y, jne.) jollain geneerisillä englanninkielisillä vastineilla (Company X, etc.). ok
Taulukko 1.16 Poistetaan alapuolinen XML-esimerkki, joka ei mahdu sivulle. ok
Taulukko 1.17, ERROR, taulukon alapuolella. ok
Luku 1.9, virheellinen viittaus/linkitys (??). ok
Taulukko 1.18 Poistetaan turha XML-esimerkki taulukon alta. ok
Luku 1.10, IM-metadata -laajennoksen tietotyyppiä etsitään väärästä paikasta. ok			
			
2 Base data
		
Luku 2.1.2 Type Coding, ERROR – IM_Coding/IM_Codings…? Boldaus koitettu tehdä kahdella tähdellä **. ok
Luku 2.1.3 Quantity info, ERROR – Nimestä puuttuu loppuosa. ok
Taulukko 2.8 ERRORit taulukon alta korjattava. ok
Luku 2.4 Terrain model – Poistetaan lopusta kohta, missä edellytetään desc-kenttään lisättävän ”Terrain model” -teksti. ok
Luku 2.4.1 ERROR – IM_Soil -> IM_soil ok
Figure 2.4 väärässä paikassa, siirrettävä Terrain modelin alle ok
Luku 2.5 Ground layer model – Poistetaan viimeinen lause, kuten kohdassa 2.4. ok
Figure 2.6, poistetaan kuva. ok